### PR TITLE
Simpler init, multiple race dates and package.json for Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export AP_API_KEY=<MY_AP_API_KEY>
 export RACEDATE=YYYY-MM-DD
 ```
 
-The RACEDATE environment variable determines which database the loader will be loading data into. The formula for the database name is elex_$RACEDATE. Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
+The `RACEDATE` environment variable determines which database the loader will be loading data into. The formula for the database name is `elex_$RACEDATE`. Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
 
 Then do this:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Edit `~/.virtualenvs/elex-loader/bin/postactivate` and add this line:
 export AP_API_KEY=<MY_AP_API_KEY>
 ```
 
-Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
+The RACEDATE environment variable determines which database the loader will be loading data into. The formula for the database name is elex_$RACEDATE. Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
 
 Then do this:
 
@@ -52,7 +52,13 @@ source ~/.virtualenvs/elex-loader/bin/postactivate
 
 * **Note**: Creates role, database and tables if they don't exist.
 ```bash
-./init.sh <RACE_DATE> # example: ./init.sh 2016-02-01
+./init.sh
+```
+
+For this or any other shell commands, you can specify the race date manually:
+
+```
+./init.sh 2016-02-01
 ```
 
 #### 2a. Updates
@@ -61,11 +67,11 @@ source ~/.virtualenvs/elex-loader/bin/postactivate
 * **Note**: You might want to run this in a loop or on a cron.
 
 ```bash
-./update.sh <RACE_DATE> # example: ./update.sh 2016-02-01
+./update.sh
 ```
 
 #### 3b. Daemonized
 The daemon runs `update.sh` every 30 seconds.
 ```bash
-./daemon.sh <RACE_DATE> # example: ./daemon.sh 2016-02-01
+./daemon.sh
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Having trouble on OS X El Capitan? See: [Can't install virtualenvwrapper on OSX 
 #### 1. Postgres
 ```bash
 brew install postgres
+./createuser.sh       # create the elex role as a superuser
 ```
 
 #### 2. Loader scripts

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Edit `~/.virtualenvs/elex-loader/bin/postactivate` and add this line:
 
 ```bash
 export AP_API_KEY=<MY_AP_API_KEY>
+export RACEDATE=YYYY-MM-DD
 ```
 
 The RACEDATE environment variable determines which database the loader will be loading data into. The formula for the database name is elex_$RACEDATE. Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
@@ -47,15 +48,15 @@ source ~/.virtualenvs/elex-loader/bin/postactivate
 #### 0. Configuration
 * Edit [candidate.csv](https://github.com/newsdev/elex-loader/blob/master/overrides/candidate.csv) and/or [race.csv](https://github.com/newsdev/elex-loader/blob/master/overrides/race.csv) if you'd like to override race descriptions and/or candidates or ballot positions with different names or descriptions.
 
-#### 0. Initial data
+#### 1. Initial data
 * Loads initial data about the race, candidates, ballot issues and reporting units.
 
-* **Note**: Creates role, database and tables if they don't exist.
+* **Note**: Creates database and tables for this date if they don't exist.
 ```bash
 ./init.sh
 ```
 
-For this or any other shell commands, you can specify the race date manually:
+For this or other shell commands, you can set the race date manually, instead of using the environmental variable (in case you need to load data for multiple dates):
 
 ```
 ./init.sh 2016-02-01

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Having trouble on OS X El Capitan? See: [Can't install virtualenvwrapper on OSX 
 #### 1. Postgres
 ```bash
 brew install postgres
-createuser elex
-psql
-    alter user elex with superuser;
-    \q
 ```
 
 #### 2. Loader scripts
@@ -35,10 +31,9 @@ Edit `~/.virtualenvs/elex-loader/bin/postactivate` and add this line:
 
 ```bash
 export AP_API_KEY=<MY_AP_API_KEY>
-export RACEDATE=YYYY-MM-DD
 ```
 
-The `RACEDATE` environment variable determines which database the loader will be loading data into. The formula for the database name is `elex_$RACEDATE`. Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
+Ask [Jeremy Bowers](mailto:jeremy.bowers@nytimes.com), [Wilson Andrews](wilson.andrews@nytimes.com) or [Tom Giratikanon](tom.giratikanon@nytimes.com) for our API key if you don't have it already.
 
 Then do this:
 
@@ -51,17 +46,12 @@ source ~/.virtualenvs/elex-loader/bin/postactivate
 #### 0. Configuration
 * Edit [candidate.csv](https://github.com/newsdev/elex-loader/blob/master/overrides/candidate.csv) and/or [race.csv](https://github.com/newsdev/elex-loader/blob/master/overrides/race.csv) if you'd like to override race descriptions and/or candidates or ballot positions with different names or descriptions.
 
-* Bootstrap your env and database.
-```
-./bootstrap.sh
-```
-
-#### 1. Initial data
+#### 0. Initial data
 * Loads initial data about the race, candidates, ballot issues and reporting units.
 
-* **Note**: Creates tables if they don't exist.
+* **Note**: Creates role, database and tables if they don't exist.
 ```bash
-./init.sh
+./init.sh <RACE_DATE> # example: ./init.sh 2016-02-01
 ```
 
 #### 2a. Updates
@@ -70,11 +60,11 @@ source ~/.virtualenvs/elex-loader/bin/postactivate
 * **Note**: You might want to run this in a loop or on a cron.
 
 ```bash
-./update.sh
+./update.sh <RACE_DATE> # example: ./update.sh 2016-02-01
 ```
 
 #### 3b. Daemonized
 The daemon runs `update.sh` every 30 seconds.
-```
-./daemon.sh
+```bash
+./daemon.sh <RACE_DATE> # example: ./daemon.sh 2016-02-01
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-mkdir -p /tmp/$RACEDATE
-
-dropdb elex_$RACEDATE
-createdb elex_$RACEDATE

--- a/createuser.sh
+++ b/createuser.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+date "+STARTED: %H:%M:%S"
+echo "------------------------------"
+
+echo "Create elex role"
+psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='elex'" | grep -q 1 || createuser elex
+
+echo "Make elex a superuser"
+psql postgres -tAc "alter user elex with superuser;"
+
+echo "------------------------------"
+date "+ENDED: %H:%M:%S"

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
+
+RACEDATE=$1
+
+if [[ $RACEDATE -eq 0 ]] ; then
+    echo 'Provide a race date, such as 2016-02-01'
+    exit 1
+fi
+
+
 while [ 1 ]; do
-    ./update.sh
+    ./update.sh $RACEDATE
     sleep 30
 done

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,12 +1,19 @@
 #!/bin/sh
 
-RACEDATE=$1
+# set RACEDATE from the first argument, if it exists
+if [[ ! -z $1 ]] ; then
+    RACEDATE=$1
+fi
 
-if [[ $RACEDATE -eq 0 ]] ; then
+if [[ -z $RACEDATE ]] ; then
     echo 'Provide a race date, such as 2016-02-01'
     exit 1
 fi
 
+if [[ -z "$AP_API_KEY" ]] ; then
+    echo "Missing environmental variable AP_API_KEY. Try 'export AP_API_KEY=MY_API_KEY_GOES_HERE'."
+    exit 1
+fi
 
 while [ 1 ]; do
     ./update.sh $RACEDATE

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+RACEDATE=$1
+
+if [[ $RACEDATE -eq 0 ]] ; then
+    echo 'Provide a race date, such as 2016-02-01'
+    exit 1
+fi
+
+if [[ -z "$AP_API_KEY" ]] ; then
+    echo "Missing environmental variable AP_API_KEY. Try 'export AP_API_KEY=MY_API_KEY_GOES_HERE'."
+    exit 1
+fi
+
 date "+STARTED: %H:%M:%S"
 echo "------------------------------"
+
+echo "Create elex role"
+psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='elex'" | grep -q 1 || createuser elex
+
+echo "Make elex a superuser"
+psql postgres -tAc "alter user elex with superuser;"
+
+echo "Drop elex_$1 if it exists"
+dropdb elex_$RACEDATE --if-exists
+
+echo "Create elex_$RACEDATE"
+psql -l | grep -q elex_$RACEDATE || createdb elex_$RACEDATE
 
 echo "Initialize races"
 psql elex_$RACEDATE -c "DROP TABLE IF EXISTS races CASCADE; CREATE TABLE races (

--- a/init.sh
+++ b/init.sh
@@ -15,12 +15,6 @@ fi
 date "+STARTED: %H:%M:%S"
 echo "------------------------------"
 
-echo "Create elex role"
-psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='elex'" | grep -q 1 || createuser elex
-
-echo "Make elex a superuser"
-psql postgres -tAc "alter user elex with superuser;"
-
 echo "Drop elex_$1 if it exists"
 dropdb elex_$RACEDATE --if-exists
 

--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-RACEDATE=$1
+# set RACEDATE from the first argument, if it exists
+if [[ ! -z $1 ]] ; then
+    RACEDATE=$1
+fi
 
-if [[ $RACEDATE -eq 0 ]] ; then
+if [[ -z $RACEDATE ]] ; then
     echo 'Provide a race date, such as 2016-02-01'
     exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "elex-loader",
+  "version": "1.0.0",
+  "description": "The NYT AP election loader scripts",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/newsdev/elex-loader.git"
+  },
+  "author": "Jeremy Bowers <jeremy.bowers@nytimes.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/newsdev/elex-loader/issues"
+  },
+  "homepage": "https://github.com/newsdev/elex-loader#readme"
+}

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+RACEDATE=$1
+
+if [[ $RACEDATE -eq 0 ]] ; then
+    echo 'Provide a race date, such as 2016-02-01'
+    exit 1
+fi
+
+if [[ -z "$AP_API_KEY" ]] ; then
+    echo "Missing environmental variable AP_API_KEY. Try 'export AP_API_KEY=MY_API_KEY_GOES_HERE'."
+    exit 1
+fi
+
 date "+STARTED: %H:%M:%S"
 echo "------------------------------"
 

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-RACEDATE=$1
+# set RACEDATE from the first argument, if it exists
+if [[ ! -z $1 ]] ; then
+    RACEDATE=$1
+fi
 
-if [[ $RACEDATE -eq 0 ]] ; then
+if [[ -z $RACEDATE ]] ; then
     echo 'Provide a race date, such as 2016-02-01'
     exit 1
 fi


### PR DESCRIPTION
Tweaks to make it easier to run `elex-loader` by itself, and easier to include in Node. 
- `init.sh` now drops and remakes the database (which `bootstrap.sh` used to do), since we now need a database for each date anyway. 
- New script `createuser.sh` creates the `elex` role and makes it a super user, just to make install simpler.
- Shell commands now optionally take a race date as an argument. (You can still set `RACEDATE=2016-02-01` as a variable.)
  - `./init.sh 2016-02-01`
  - `./update.sh 2016-02-01`
  - `./daemon.sh 2016-02-01`
- Add `package.json` so we can install it as a Node module.
- Updated docs to reflect this.

cc @jeremyjbowers 
