### PR TITLE
Call post-update in election frontend app

### DIFF
--- a/scripts/stg.sh
+++ b/scripts/stg.sh
@@ -19,6 +19,6 @@ fi
 
 while [ 1 ]; do
     . /home/ubuntu/.virtualenvs/elex-loader/bin/activate && . /home/ubuntu/.virtualenvs/elex-loader/bin/postactivate && /home/ubuntu/elex-loader/scripts/stg/update.sh $RACEDATE
-    export NODE_ENV="staging" && cd /home/ubuntu/election-2016/ && npm run ic $RACEDATE && npm run bake $RACEDATE
+    export NODE_ENV="staging" && cd /home/ubuntu/election-2016/ && npm run post-update $RACEDATE
     sleep 30
 done


### PR DESCRIPTION
Calling `post-update` instead of `ic` and `bake` will give the app some flexibility. For instance, we may not need to re-upload JS/CSS on load of AP data. 

cc @jeremyjbowers 
